### PR TITLE
Lazy load GCS bucket to prevent AuthErrors when no reads/writes expected

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -10,10 +10,11 @@ import {
     verifyConfiguration,
 } from './gcp-specific';
 import type { RemoteCacheImplementation } from 'nx-remotecache-custom/types/remote-cache-implementation';
+import type { Bucket } from '@google-cloud/storage';
 
 export default createCustomRunner<Partial<GCPBucketIdentifier>>(
     async (options): Promise<RemoteCacheImplementation> => {
-        let bucket;
+        let bucket: Bucket | undefined;
         initEnv(options);
         const configuration = buildConfiguration(options);
         const verifiedConfiguration = verifyConfiguration(configuration);
@@ -27,11 +28,17 @@ export default createCustomRunner<Partial<GCPBucketIdentifier>>(
         return {
             name: 'Google Cloud Bucket',
             fileExists: async (filename) => {
-                const bucketFile = constructGCSFileReference(await getBucket(), filename);
+                const bucketFile = constructGCSFileReference(
+                    await getBucket(),
+                    filename,
+                );
                 return await bucketFileExists(bucketFile);
             },
             retrieveFile: async (filename) => {
-                const bucketFile = constructGCSFileReference(await getBucket(), filename);
+                const bucketFile = constructGCSFileReference(
+                    await getBucket(),
+                    filename,
+                );
                 const downloadedFile = bucketFile.download();
                 return Readable.from(await downloadedFile);
             },

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,25 +13,31 @@ import type { RemoteCacheImplementation } from 'nx-remotecache-custom/types/remo
 
 export default createCustomRunner<Partial<GCPBucketIdentifier>>(
     async (options): Promise<RemoteCacheImplementation> => {
+        let bucket;
         initEnv(options);
         const configuration = buildConfiguration(options);
         const verifiedConfiguration = verifyConfiguration(configuration);
-        const bucket = await getGCSBucket(verifiedConfiguration);
+        const getBucket = async () => {
+            if (!bucket) {
+                bucket = await getGCSBucket(verifiedConfiguration);
+            }
+            return bucket;
+        };
 
         return {
             name: 'Google Cloud Bucket',
             fileExists: async (filename) => {
-                const bucketFile = constructGCSFileReference(bucket, filename);
+                const bucketFile = constructGCSFileReference(await getBucket(), filename);
                 return await bucketFileExists(bucketFile);
             },
             retrieveFile: async (filename) => {
-                const bucketFile = constructGCSFileReference(bucket, filename);
+                const bucketFile = constructGCSFileReference(await getBucket(), filename);
                 const downloadedFile = bucketFile.download();
                 return Readable.from(await downloadedFile);
             },
             storeFile: async (filename, stream) => {
                 const uploadStream = constructGCSFileReference(
-                    bucket,
+                    await getBucket(),
                     filename,
                 ).createWriteStream();
                 await pipeline(stream, uploadStream);


### PR DESCRIPTION
**Problem**
In cases where we disable both read + write remote access (i.e. CI/CD), this library throws an error:
```
ApiError: Caller does not have storage.buckets.get access to the Google Cloud Storage bucket. Permission 'storage.buckets.get' denied on resource (or it may not exist).
```

**Solution**
Only attempt to connect to GCS and exercise the authentication if we're actually going to be using the read/write connection. Support for this behavior was added upstream in https://github.com/NiklasPor/nx-remotecache-custom/pull/33

NOTE: Apologies I did this from the web-ui, so bucket may need a type defined.